### PR TITLE
The ID of a newly inserted row can be retrieved using the `insertId` …

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -102,11 +102,9 @@ class MySqlConnection {
 
     const keys = Object.keys(obj);
     const values = keys.map(key => obj[key]);
-    await this.query(sql[0], ...values);
+    const result = await this.query(sql, ...values);
 
-    const rows = await this.query(sql[1]);
-    const id = rows[0]['last_insert_id()'];
-    return id;
+    return result.insertId;
   }
 
   /**

--- a/src/sql-util.js
+++ b/src/sql-util.js
@@ -55,12 +55,8 @@ class SqlUtil {
     const values = keys.map(key => obj[key]);
     const cols = keys.join(', ');
     const placeholders = values.map(() => '?').join(', ');
-    const sql1 = `insert into ${tableName} (${cols}) values(${placeholders})`;
+    const sql = `insert into ${tableName} (${cols}) values(${placeholders})`;
 
-    const col = 'last_insert_id()';
-    const sql2 = `select ${col}`;
-
-    const sql = [sql1, sql2];
     this.log('insert: sql =', sql);
     return sql;
   }

--- a/src/sql-util.test.js
+++ b/src/sql-util.test.js
@@ -34,10 +34,7 @@ describe('sql', () => {
 
   test('insert', () => {
     const obj = {foo: true, bar: 7, baz: 'qux'};
-    const expected = [
-      `insert into ${tableName} (foo, bar, baz) values(?, ?, ?)`,
-      'select last_insert_id()'
-    ];
+    const expected = `insert into ${tableName} (foo, bar, baz) values(?, ?, ?)`;
     expect(sqlUtil.insert(tableName, obj)).toEqual(expected);
   });
 


### PR DESCRIPTION
…propert of the result.

Researching some other issues we are having, I noticed in the docs for [mysql](https://github.com/mysqljs/mysql) that an [inserted ID can be retrieved by using the `insertId` property of the result](https://github.com/mysqljs/mysql#getting-the-id-of-an-inserted-row).

I'm not really clear on what `upsert` is striving to do, but chances are the same is true for that method as well.